### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![smithery badge](https://smithery.ai/badge/@mikechao/balldontlie-mcp)](https://smithery.ai/server/@mikechao/balldontlie-mcp)
 
+<a href="https://glama.ai/mcp/servers/@mikechao/balldontlie-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mikechao/balldontlie-mcp/badge" alt="balldontlie-mcp MCP server" />
+</a>
+
 An MCP Server implementation that integrates the [Balldontlie API](https://www.balldontlie.io/), to provide information about players, teams and games for the NBA, NFL and MLB.
 
 ## Tools


### PR DESCRIPTION
This PR adds a badge for the [balldontlie-mcp](https://glama.ai/mcp/servers/@mikechao/balldontlie-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mikechao/balldontlie-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mikechao/balldontlie-mcp/badge" alt="balldontlie-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.